### PR TITLE
command correction

### DIFF
--- a/docs/platforms/azure.md
+++ b/docs/platforms/azure.md
@@ -44,7 +44,7 @@ For this instance, we will run Coder as a system service, however you can run Co
 In the Azure VM instance, run the following command to install Coder
 
 ```console
-curl -fsSL <https://coder.com/install.sh> | sh
+curl -fsSL https://coder.com/install.sh | sh
 ```
 
 ## Run Coder


### PR DESCRIPTION
removed <> from command for easy copy and paste use for users

with <> it leads to following syntax error
-bash: syntax error near unexpected token `|'